### PR TITLE
Update repo to follow Gem development conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ build-iPhoneSimulator/
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
+traceloop-sdk/Gemfile.lock
+opentelemetry-semantic_conventions_ai/Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-source "https://rubygems.org"
-
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
-
-# gem "rails"

--- a/semantic_conventions_ai/Gemfile
+++ b/semantic_conventions_ai/Gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-# gem "rails"
+gemspec

--- a/traceloop-sdk/Gemfile
+++ b/traceloop-sdk/Gemfile
@@ -4,4 +4,4 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-# gem "rails"
+gemspec


### PR DESCRIPTION
Adds a few quick updates from bundling the repo locally.
* Remove Gemfile from root directory
  * The root directory does not appear to need a Gemfile as it is not a library or app, and it doesn't seem like that will be the case in the future
* Add `gemspec` to the repository gem's Gemfiles.
  * This allows the gemspec files to specify the gem's dependencies which can be installed with `bundle install` by contributors. The docs for the method can be found [here](https://bundler.io/v2.5/man/gemfile.5.html#GEMSPEC) 
* Add lock files to `.gitignore`
  * As the directories in this repo are gems, they will be targeting a range of versions, not a specific "locked" set of dependencies. By ignoring the lock files, the repo stays in a clean state after bundling, and the various gems can be developed against a range of dependency versions. 
  
These conventions follow what is outlined in https://yehudakatz.com/2010/12/16/clarifying-the-roles-of-the-gemspec-and-gemfile/.